### PR TITLE
doc: Give more visibility to note on running the analysis on build server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Sending the results of running Faux Pas to Codacy involves the steps below, whic
 3.  Send the results to Codacy
 4.  Finally, signal that Codacy can use the sent results and start a new analysis
 
+> When the option **“Run analysis through build server”** is enabled, the Codacy analysis will not start until you call the endpoint `/2.0/commit/{commitUuid}/resultsFinal` signalling that Codacy can use the sent results and start a new analysis.
+
 With script:
 
 ```bash
@@ -79,10 +81,6 @@ curl -XPOST -L -H "project-token: $PROJECT_TOKEN" \
 	-H "Content-type: application/json" \
 	"$CODACY_URL/2.0/commit/$COMMIT/resultsFinal"
 ```
-
-> When the option **“Run analysis through build server”** is enabled, the Codacy analysis will not start until you call the endpoint `/2.0/commit/{commitUuid}/resultsFinal` signalling that Codacy can use the sent results and start a new analysis.
-
-* * *
 
 ## Command line flags
 


### PR DESCRIPTION
Applies the same change that we discussed here: https://github.com/codacy/codacy-roslyn/pull/10#discussion_r1007168657